### PR TITLE
optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY requirements.txt /usr/src/app/
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY browser.py /usr/src/app/browser.py
-CMD [ "python", "./browser.py" ]
+ENTRYPOINT [ "python", "./browser.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,11 @@
-FROM ubuntu
+FROM python:2.7-slim
 MAINTAINER vivekjuneja@gmail.com
 
-# Add the application resources URL
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) main universe" >> /etc/apt/sources.list
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
 
-RUN apt-get update
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
 
-RUN apt-get install -y tar git curl nano wget dialog net-tools build-essential
-
-RUN apt-get install -y python python-dev python-distribute python-pip
-
-WORKDIR /data
-COPY * /data/
-
-RUN pip install -r requirements.txt
-
-ENTRYPOINT ["python", "browser.py"]
-
-
+COPY browser.py /usr/src/app/browser.py
+CMD [ "python", "./browser.py" ]


### PR DESCRIPTION
Your dockerfile would result in an unoptimized image in my opinion.

First, you are missing version tagging (python version, ubuntu version, ...) 

Next, I'd change all these separate run commands into one, to have 1 layer for this part of the build:

``` Dockerfile
RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) main universe" >> /etc/apt/sources.list
RUN apt-get update
RUN apt-get install -y tar git curl nano wget dialog net-tools build-essential
RUN apt-get install -y python python-dev python-distribute python-pip
```

Becomes 

``` Dockerfile
RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) main universe" >> /etc/apt/sources.list && \
    apt-get update && \
    apt-get install -y tar git curl nano wget dialog net-tools build-essential && \
    apt-get install -y python python-dev python-distribute python-pip
```

Then, I'd tag on `apt-get autoremove -y` and more commands **within the same layer** to clean up that layer.

Making it

``` Dockerfile
RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(lsb_release -sc) main universe" >> /etc/apt/sources.list && \
    apt-get update && \
    apt-get install -y tar git curl nano wget dialog net-tools build-essential && \
    apt-get install -y python python-dev python-distribute python-pip && \
    apt-get autoremove -y
```

Next, I believe you are including dev dependencies not required to run in production - I think it would just be best to base on the official Python image.

``` Dockerfile
FROM python:2.7-slim
...

```

final image after build: 207MB 

Maybe it could be made smaller if based on [alpine-python2](https://registry.hub.docker.com/u/frolvlad/alpine-python2/) (50 MB)
see it's [Dockerfile here](https://github.com/frol/docker-alpine-python2/blob/master/Dockerfile)

but then, I'd be concerned about stability/support 
